### PR TITLE
feat: add local stream option

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ Thank you for using Imou integration for Home Assistant. If you have any questio
 How to use？https://open.imoulife.com/book/guide/haDev.html
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Imou-OpenPlatform&repository=https%3A%2F%2Fgithub.com%2FImou-OpenPlatform%2FImou-Home-Assistant.git)
+
+## Configuration
+
+The integration can be configured through its options. To use a local RTSP stream instead of the cloud stream:
+
+1. Open the Imou integration options in Home Assistant.
+2. Enable **use_local_stream**.
+3. Provide the camera **rtsp_url**, **username**, and **password**.
+
+When enabled, the camera entity will expose `CameraEntityFeature.STREAM` and stream locally using `rtsp://username:password@rtsp_url`.

--- a/custom_components/imou_life/camera.py
+++ b/custom_components/imou_life/camera.py
@@ -20,6 +20,10 @@ from .const import (
     PARAM_LIVE_PROTOCOL,
     PARAM_DOWNLOAD_SNAP_WAIT_TIME,
     PARAM_HEADER_DETECT,
+    PARAM_USE_LOCAL_STREAM,
+    PARAM_RTSP_URL,
+    PARAM_USERNAME,
+    PARAM_PASSWORD,
 )
 from .entity import ImouEntity
 
@@ -55,6 +59,13 @@ class ImouCamera(ImouEntity, Camera):
 
     async def stream_source(self) -> str | None:
         """GET STREAMING ADDRESS."""
+        if self._config_entry.options.get(PARAM_USE_LOCAL_STREAM):
+            rtsp_url = self._config_entry.options.get(PARAM_RTSP_URL)
+            username = self._config_entry.options.get(PARAM_USERNAME)
+            password = self._config_entry.options.get(PARAM_PASSWORD)
+            if rtsp_url and username and password:
+                return f"rtsp://{username}:{password}@{rtsp_url}"
+            return None
         try:
             return await self._coordinator.device_manager.async_get_device_stream(
                 self._device,

--- a/custom_components/imou_life/config_flow.py
+++ b/custom_components/imou_life/config_flow.py
@@ -28,6 +28,10 @@ from .const import (
     CONF_HTTPS,
     CONF_HTTP,
     PARAM_LIVE_PROTOCOL,
+    PARAM_USE_LOCAL_STREAM,
+    PARAM_RTSP_URL,
+    PARAM_USERNAME,
+    PARAM_PASSWORD,
 )
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -141,6 +145,10 @@ class ImouOptionsFlow(config_entries.OptionsFlow):
                         vol.Required(PARAM_ROTATION_DURATION, default=500): vol.All(
                             vol.Coerce(int), vol.Range(min=100, max=10000)
                         ),
+                        vol.Required(PARAM_USE_LOCAL_STREAM, default=False): bool,
+                        vol.Optional(PARAM_RTSP_URL, default=""): str,
+                        vol.Optional(PARAM_USERNAME, default=""): str,
+                        vol.Optional(PARAM_PASSWORD, default=""): str,
                     }
                 ),
                 self.config_entry.options,

--- a/custom_components/imou_life/const.py
+++ b/custom_components/imou_life/const.py
@@ -37,6 +37,10 @@ PARAM_PTZ = "ptz"
 PARAM_OPTION = "option"
 PARAM_COUNT_DOWN_SWITCH = "count_down_switch"
 PARAM_OVERCHARGE_SWITCH = "overcharge_switch"
+PARAM_USE_LOCAL_STREAM = "use_local_stream"
+PARAM_RTSP_URL = "rtsp_url"
+PARAM_USERNAME = "username"
+PARAM_PASSWORD = "password"
 
 # service
 SERVICE_RESTART_DEVICE = "restart_device"


### PR DESCRIPTION
## Summary
- add `use_local_stream` option with RTSP credentials
- allow camera to stream directly via `rtsp://username:password@...`
- document local stream configuration in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant.components.imou_life')*

------
https://chatgpt.com/codex/tasks/task_e_6895dec01e0c832183e71c3c6d5c9495